### PR TITLE
convert match to const array lookup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,21 +4,21 @@
 //! A macro with two main purposes:
 //! - attaching static properties to `enum` variants
 //! - reducing the size of pointers to static records
-//! 
+//!
 //! The advantage in both cases is that the `enum` itself contains no data, and
 //! can be as small as a byte.
-//! 
+//!
 //! # Example
-//! 
+//!
 //! ```rust
 //! use enum_properties::enum_properties;
-//! 
+//!
 //! struct SolidProperties {
 //!     verts: i32,
 //!     edges: i32,
 //!     faces: i32,
 //! }
-//! 
+//!
 //! enum_properties! {
 //!     #[derive(Clone, Copy, Debug)]
 //!     enum PlatonicSolid: SolidProperties {
@@ -49,37 +49,37 @@
 //!         },
 //!     }
 //! }
-//! 
+//!
 //! fn main() {
 //!     let cube = PlatonicSolid::Cube;
 //!     assert_eq!(cube.verts - cube.edges + cube.faces, 2);
 //! }
 //! ```
-//! 
+//!
 
 /// Defines a new `enum` and implements [`Deref`] for it.
-/// 
+///
 /// The `enum` will [`Deref`] to a variant-specific [`static` item].
-/// 
-/// To specify default properties, use the following syntax (inspired by 
-/// [functional update syntax]): 
-/// 
+///
+/// To specify default properties, use the following syntax (inspired by
+/// [functional update syntax]):
+///
 /// # Example
 /// ```rust
 /// use enum_properties::enum_properties;
-/// 
+///
 /// pub struct EnemyProperties {
 ///     pub health:     i32,
 ///     pub is_solid:   bool,
 ///     pub is_flying:  bool,
 /// }
-/// 
+///
 /// const DEFAULT_ENEMY_PROPERTIES: EnemyProperties = EnemyProperties {
 ///     health:     10,
 ///     is_solid:   true,
 ///     is_flying:  false,
 /// };
-/// 
+///
 /// enum_properties! {
 ///     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 ///     pub enum EnemyKind: EnemyProperties {
@@ -101,7 +101,7 @@
 /// [`Deref`]: https://doc.rust-lang.org/std/ops/trait.Deref.html
 /// [`static` item]: https://doc.rust-lang.org/reference/items/static-items.html
 /// [functional update syntax]: https://doc.rust-lang.org/reference/expressions/struct-expr.html#functional-update-syntax
-/// 
+///
 #[macro_export]
 macro_rules! enum_properties {
     (
@@ -116,19 +116,20 @@ macro_rules! enum_properties {
         $public enum $Enum {
             $($variant),*
         }
-        
+
         impl core::ops::Deref for $Enum {
             type Target = $EnumProperties;
             fn deref(&self) -> &Self::Target {
-                match self {
-                    $($Enum::$variant => &$EnumProperties {
+                const PROPERTIES: [$EnumProperties; 3] = [
+                    $($EnumProperties {
                         $($field: $value),* $(, .. $default)?
                     }),*
-                }
+                ];
+                &PROPERTIES[*self as usize]
             }
         }
     };
-    
+
     (
         $(#[$($m:tt)*])*
         $public:vis enum $Enum:ident : $EnumProperties:ident {
@@ -141,17 +142,17 @@ macro_rules! enum_properties {
         $public enum $Enum {
             $($variant),*
         }
-        
+
         impl core::ops::Deref for $Enum {
             type Target = $EnumProperties;
             fn deref(&self) -> &Self::Target {
-                match self {
-                    $($Enum::$variant => &$EnumProperties {
-                        $($field: $value),* , .. $default
+                const PROPERTIES: [$EnumProperties; 3] = [
+                    $($EnumProperties {
+                        $($field: $value),* $(, .. $default)?
                     }),*
-                }
+                ];
+                &PROPERTIES[*self as usize]
             }
         }
     };
 }
-


### PR DESCRIPTION
Step 1 for complex enums: replace the `match` in the `Defer` `impl` with an array lookup.

(Sorry for the gratuitous whitespace mess, my editor did it in my back)